### PR TITLE
Validate winding order of rings (correct by reversing ring if needed)

### DIFF
--- a/snap/snap.go
+++ b/snap/snap.go
@@ -68,7 +68,7 @@ func addPointsAndSnap(ix *PointIndex, polygon *geom.Polygon) *geom.Polygon {
 			// inner rings (ringIdx != 0) should be clockwise
 			shouldBeClockwise := ringIdx != 0
 			// winding order is reversed if incorrect
-			validateWindingOrder(deduplicatedRing, shouldBeClockwise)
+			ensureCorrectWindingOrder(deduplicatedRing, shouldBeClockwise)
 			newPolygon = append(newPolygon, deduplicatedRing)
 		}
 	}
@@ -77,7 +77,7 @@ func addPointsAndSnap(ix *PointIndex, polygon *geom.Polygon) *geom.Polygon {
 
 // validate winding order (CCW for outer rings, CW for inner rings)
 // if winding order is incorrect, ring is reversed to correct winding order
-func validateWindingOrder(ring [][2]float64, shouldBeClockwise bool) {
+func ensureCorrectWindingOrder(ring [][2]float64, shouldBeClockwise bool) {
 	steps := []string{}
 	stepCounts := map[bool]int{true: 0, false: 0}
 	for i := 0; i < len(ring); i++ {

--- a/snap/snap.go
+++ b/snap/snap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 
 	"github.com/go-spatial/geom"
 	"github.com/pdok/texel/processing"
@@ -62,19 +63,109 @@ func addPointsAndSnap(ix *PointIndex, polygon *geom.Polygon) *geom.Polygon {
 				newPolygon = append(newPolygon, newRing)
 			}
 		default:
-			// deduplicate points in the ring, then add to the polygon
-			newPolygon = append(newPolygon, kmpDeduplicate(newRing))
+			// deduplicate points in the ring, check winding order, then add to the polygon
+			deduplicatedRing := kmpDeduplicate(newRing)
+			// inner rings (ringIdx != 0) should be clockwise
+			shouldBeClockwise := ringIdx != 0
+			// winding order is reversed if incorrect
+			validateWindingOrder(deduplicatedRing, shouldBeClockwise)
+			newPolygon = append(newPolygon, deduplicatedRing)
 		}
 	}
 	return (*geom.Polygon)(&newPolygon)
+}
+
+// validate winding order (CCW for outer rings, CW for inner rings)
+// if winding order is incorrect, ring is reversed to correct winding order
+func validateWindingOrder(ring [][2]float64, shouldBeClockwise bool) {
+	steps := []string{}
+	stepCounts := map[bool]int{true: 0, false: 0}
+	for i := 0; i < len(ring); i++ {
+		steps = append(steps, directionOfStep(ring[i], ring[(i+1)%len(ring)]))
+		// need at least a pair of steps to check winding order
+		if len(steps) <= 1 {
+			continue
+		}
+		// steps back (e.g., 'R,L') or repeated steps (e.g., 'R,R') count as a step for the winding order the ring should have
+		if steps[len(steps)-2] == oppositeDirectionOf(steps[len(steps)-1]) || steps[len(steps)-2] == steps[len(steps)-1] {
+			stepCounts[shouldBeClockwise]++
+		} else {
+			stepCounts[isClockwise(steps[len(steps)-2:])]++
+		}
+	}
+	if stepCounts[shouldBeClockwise] < stepCounts[!shouldBeClockwise] {
+		slices.Reverse(ring)
+	}
+}
+
+// returns if pair of steps is clockwise
+func isClockwise(stepsPair []string) bool {
+	clockwiseSteps := []string{
+		"U,R",   // up, then right
+		"U,RU",  // up, then right+up
+		"U,RD",  // up, then right+down
+		"RU,R",  // right+up, then right
+		"RU,RD", // right+up, then right+down
+		"RU,D",  // right+up, then down
+		"R,D",   // right, then down
+		"R,RD",  // right, then right+down
+		"R,LD",  // right, then left+down
+		"RD,D",  // right+down, then down
+		"RD,LD", // right+down, then left+down
+		"RD,L",  // right+down, then left
+		"D,L",   // down, then left
+		"D,LU",  // down, then left+up
+		"D,LD",  // down, then left+down
+		"LD,L",  // left+down, then left
+		"LD,LU", // left+down, then left+up
+		"LD,U",  // left+down, then up
+		"L,U",   // left, then up
+		"L,LU",  // left, then left+up
+		"L,RU",  // left, then right+up
+		"LU,R",  // left+up, then right
+		"LU,RU", // left+up, then right+up
+		"LU,U",  // left+up, then up
+	}
+	return slices.Contains(clockwiseSteps, strings.Join(stepsPair, ","))
+}
+
+// returns opposite of a direction
+func oppositeDirectionOf(direction string) string {
+	opposites := map[string]string{
+		"U":  "D",
+		"D":  "U",
+		"R":  "L",
+		"L":  "R",
+		"RU": "LD",
+		"RD": "LU",
+		"LU": "RD",
+		"LD": "RU",
+	}
+	return opposites[direction]
+}
+
+// determines direction of a step from one point to another
+func directionOfStep(from, to [2]float64) string {
+	direction := ""
+	if to[0] > from[0] {
+		direction += "R"
+	} else if to[0] < from[0] {
+		direction += "L"
+	}
+	if to[1] > from[1] {
+		direction += "U"
+	} else if to[1] < from[1] {
+		direction += "D"
+	}
+	return direction
 }
 
 // deduplication using an implementation of the Knuth-Morris-Pratt algorithm
 //
 //nolint:cyclop,funlen
 func kmpDeduplicate(newRing [][2]float64) [][2]float64 {
-	dedupedRing := make([][2]float64, len(newRing))
-	copy(dedupedRing, newRing)
+	deduplicatedRing := make([][2]float64, len(newRing))
+	copy(deduplicatedRing, newRing)
 	// map of indices to remove, sorted by starting index of each sequence to remove
 	indicesToRemove := sortedmap.New(len(newRing), func(x, y interface{}) bool {
 		return x.([2]int)[0] < y.([2]int)[0]
@@ -220,13 +311,13 @@ func kmpDeduplicate(newRing [][2]float64) [][2]float64 {
 	offset := 0
 	for _, key := range indicesToRemove.Keys() {
 		sequence := indicesToRemove.Map()[key].([2]int)
-		dedupedRing = append(dedupedRing[:sequence[0]-offset], dedupedRing[sequence[1]-offset:]...)
+		deduplicatedRing = append(deduplicatedRing[:sequence[0]-offset], deduplicatedRing[sequence[1]-offset:]...)
 		offset += sequence[1] - sequence[0]
 	}
-	return dedupedRing
+	return deduplicatedRing
 }
 
-// kmpSearchAll repeatedly calls kmpSearch, returning all starting indexes of 'find' in 'corpus'
+// repeatedly calls kmpSearch, returning all starting indexes of 'find' in 'corpus'
 func kmpSearchAll(corpus, find [][2]float64) []int {
 	matches := []int{}
 	offset := 0
@@ -247,7 +338,7 @@ func kmpSearchAll(corpus, find [][2]float64) []int {
 	return matches
 }
 
-// kmpSearch returns the index (0 based) of the start of the string 'find' in 'corpus', or returns the length of 'corpus' on failure.
+// returns the index (0 based) of the start of 'find' in 'corpus', or returns the length of 'corpus' on failure
 func kmpSearch(corpus, find [][2]float64) int {
 	m, i := 0, 0
 	table := make([]int, max(len(corpus), 2))
@@ -271,7 +362,7 @@ func kmpSearch(corpus, find [][2]float64) int {
 	return len(corpus)
 }
 
-// kmpTable populates the partial match table 'table' for the string 'find'.
+// populates the partial match table 'table' for 'find'
 func kmpTable(find [][2]float64, table []int) {
 	pos, cnd := 2, 0
 	table[0], table[1] = -1, 0

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -59,7 +59,7 @@ func Test_snapPolygon(t *testing.T) {
 			}},
 		},
 		{
-			name:   "dedupe this",
+			name:   "needs deduplication",
 			matrix: newSimpleTileMatrix(16.0, 5, 0.5),
 			polygon: &geom.Polygon{{
 				{0.0, 0.0},
@@ -85,7 +85,33 @@ func Test_snapPolygon(t *testing.T) {
 			}},
 		},
 		{
-			name:   "dedupe this longer one",
+			name:   "needs deduplication and reversal",
+			matrix: newSimpleTileMatrix(16.0, 5, 0.5),
+			polygon: &geom.Polygon{{
+				{0.0, 2.4},
+				{2.0, 2.4},
+				{15.0, 2.4},
+				{15.0, 2.3},
+				{2.0, 2.3},
+				{2.0, 2.2},
+				{15.0, 2.2},
+				{15.0, 2.1},
+				{2.0, 2.1},
+				{2.0, 2.0},
+				{15.0, 2.0},
+				{15.0, 0.0},
+				{0.0, 0.0},
+			}},
+			want: &geom.Polygon{{
+				{0.25, 0.25},
+				{15.25, 0.25},
+				{15.25, 2.25},
+				{2.25, 2.25},
+				{0.25, 2.25},
+			}},
+		},
+		{
+			name:   "needs deduplication with one zigzag",
 			matrix: newSimpleTileMatrix(16.0, 5, 0.5),
 			polygon: &geom.Polygon{{
 				{0.0, 0.0},
@@ -117,7 +143,7 @@ func Test_snapPolygon(t *testing.T) {
 			}},
 		},
 		{
-			name:   "dedupe this double zig zag",
+			name:   "needs deduplication with more than one zigzag",
 			matrix: newSimpleTileMatrix(16.0, 5, 0.5),
 			polygon: &geom.Polygon{{
 				{0.0, 0.0},


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

https://dev.kadaster.nl/jira/browse/PDOK-15685

Volgens conventie horen outer rings counter-clockwise te lopen, en inner rings clockwise. Winding order van de ring wordt bepaald, wanneer deze niet voldoet aan de conventie, wordt de ring omgedraaid.

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Nieuwe feature
- Verbetering oude feature
- Aanpassing van de configuratie

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)