### PR TITLE
fix line intersects (fall back to floats)

### DIFF
--- a/intgeom/intgeom.go
+++ b/intgeom/intgeom.go
@@ -11,6 +11,8 @@
 // You are not required to use this.
 package intgeom
 
+import "github.com/go-spatial/geom/planar"
+
 const (
 	debug     = false
 	Precision = 1e09
@@ -33,40 +35,9 @@ func FromGeomOrd(o float64) int64 {
 // there is one. Ok will be true if it found an intersection point and if the
 // point is on both lines.
 // ref: https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line
-// TODO this should be in an "intplanar" package
-func SegmentIntersect(l1, l2 Line) (pt [2]int64, ok bool) {
-	x1, y1 := l1.Point1().X(), l1.Point1().Y()
-	x2, y2 := l1.Point2().X(), l1.Point2().Y()
-	x3, y3 := l2.Point1().X(), l2.Point1().Y()
-	x4, y4 := l2.Point2().X(), l2.Point2().Y()
-
-	deltaX12 := x1 - x2
-	deltaX13 := x1 - x3
-	deltaX34 := x3 - x4
-	deltaY12 := y1 - y2
-	deltaY13 := y1 - y3
-	deltaY34 := y3 - y4
-	denom := (deltaX12 * deltaY34) - (deltaY12 * deltaX34)
-
-	// The lines are parallel or they overlap. No single point.
-	if denom == 0 {
-		return pt, false
-	}
-
-	xnom := (((x1 * y2) - (y1 * x2)) * deltaX34) - (deltaX12 * ((x3 * y4) - (y3 * x4)))
-	ynom := (((x1 * y2) - (y1 * x2)) * deltaY34) - (deltaY12 * ((x3 * y4) - (y3 * x4)))
-	bx := xnom / denom
-	by := ynom / denom
-	if bx == -0 {
-		bx = 0
-	}
-	if by == -0 {
-		by = 0
-	}
-
-	t := ((deltaX13 * deltaY34) - (deltaY13 * deltaX34)) / denom
-	u := -((deltaX12 * deltaY13) - (deltaY12 * deltaX13)) / denom
-
-	intersects := u >= 0.0 && u <= 1.0 && t >= 0.0 && t <= 1.0
-	return [2]int64{bx, by}, intersects
+// TODO implement this with integers
+func SegmentIntersect(l1, l2 Line) ([2]int64, bool) {
+	intersection, intersects := planar.SegmentIntersect(l1.ToGeomLine(), l2.ToGeomLine())
+	intIntersection := [2]int64{FromGeomOrd(intersection[0]), FromGeomOrd(intersection[0])}
+	return intIntersection, intersects
 }

--- a/snap/pointindex_test.go
+++ b/snap/pointindex_test.go
@@ -1,6 +1,7 @@
 package snap
 
 import (
+	"github.com/go-spatial/geom/encoding/wkt"
 	"github.com/pdok/texel/intgeom"
 	"os"
 	"testing"
@@ -365,6 +366,42 @@ func TestPointIndex_SnapClosestPoints(t *testing.T) {
 			got := ix.SnapClosestPoints(tt.line)
 			if !assert.EqualValues(t, tt.want, got) {
 				t.Errorf("SnapClosestPoints() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPointIndex_lineIntersects(t *testing.T) {
+	tests := []struct {
+		name   string
+		extent intgeom.Extent
+		line   intgeom.Line
+		want   bool
+	}{
+		{
+			name: "false positive with naive integer intersect implementation",
+			extent: intgeom.Extent{
+				135196160000000,
+				516981760000000,
+				135202880000000,
+				516988480000000,
+			},
+			line: intgeom.Line{
+				{135201147999999, 516929654000000},
+				{135145991000000, 516996354000000},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ix := &PointIndex{
+				intExtent: tt.extent,
+			}
+			got := ix.lineIntersects(tt.line)
+			if tt.want != got {
+				t.Logf("extent = %v", wkt.MustEncode(tt.extent.ToGeomExtent()))
+				t.Errorf("lineIntersects(%v) = %v, want %v", wkt.MustEncode(tt.line.ToGeomLine()), got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Omschrijving

Voor line(segment) intersects terug naar de float implementatie.

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)