### PR TITLE
discard points and lines for now

### DIFF
--- a/snap/snap.go
+++ b/snap/snap.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	keepPointsAndLines      = false // TODO do something with polys that collapsed into points and lines
 	internalPixelResolution = 16
 )
 
@@ -151,7 +152,7 @@ func cleanupNewRing(newRing [][2]float64, isOuter bool) [][2]float64 {
 	case 0:
 		return nil
 	case 1, 2:
-		if isOuter {
+		if isOuter && keepPointsAndLines {
 			// keep outer ring as point or line
 			return newRing
 		}


### PR DESCRIPTION
# Omschrijving

discard points and lines for now

## Type verandering

- Aanpassing van de configuratie

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)