### PR TITLE
fix lastElement()

### DIFF
--- a/snap/snap.go
+++ b/snap/snap.go
@@ -447,7 +447,7 @@ func kmpTable(find [][2]float64, table []int) {
 
 func lastElement[T any](elements []T) *T {
 	length := len(elements)
-	if length > 1 {
+	if length > 0 {
 		return &elements[length-1]
 	}
 	return nil

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -202,15 +202,25 @@ func Test_snapPolygon(t *testing.T) {
 				{69878.365, 445712.156},
 				{69879.413, 445710.912},
 				{69837.833, 445705.673},
-				{69840.279, 445755.872},
 			}},
 			want: map[tms20.TMID]geom.Polygon{5: {{
-				{69840.8, 445753.12},
 				{69840.8, 445753.12},
 				{69840.8, 445712.8},
 				{69881.12, 445712.8},
 				{69840.8, 445712.8},
 			}}},
+		},
+		{
+			name:  "lines and points are filtered out (for now)",
+			tms:   loadEmbeddedTileMatrixSet(t, "NetherlandsRDNewQuad"),
+			tmIDs: []tms20.TMID{0},
+			polygon: geom.Polygon{{
+				{90713.55, 530388.466},
+				{90741.04, 530328.675},
+				{90673.689, 530324.552},
+				{90664.068, 530379.532},
+			}},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Omschrijving

fix lastElement() which caused dupe vertices

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)