### PR TITLE
fix filtering out small rings after deduping

### DIFF
--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -220,7 +220,19 @@ func Test_snapPolygon(t *testing.T) {
 				{90673.689, 530324.552},
 				{90664.068, 530379.532},
 			}},
-			want: nil,
+			want: map[tms20.TMID]geom.Polygon{0: nil},
+		},
+		{
+			name:  "ring length < 3 _after_ deduping, also should be filtered out",
+			tms:   loadEmbeddedTileMatrixSet(t, "NetherlandsRDNewQuad"),
+			tmIDs: []tms20.TMID{0},
+			polygon: geom.Polygon{{
+				{211124.566, 574932.941},
+				{211142.954, 574988.796},
+				{211059.858, 574971.321},
+				{211163.163, 574994.581},
+			}},
+			want: map[tms20.TMID]geom.Polygon{0: nil},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

fix filtering out small rings after deduping

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)