### PR TITLE
Revert "add a dedupe test"

### DIFF
--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -194,13 +194,6 @@ func TestSnap_snapPolygon(t *testing.T) {
 			}}}},
 		},
 		{
-			name:    "needs deduplication, 3 same, 1 different point",
-			tms:     loadEmbeddedTileMatrixSet(t, "NetherlandsRDNewQuad"),
-			tmIDs:   []tms20.TMID{0},
-			polygon: geom.Polygon{{{88843.117, 447720.147}, {88880.366, 447732.897}, {88881.636, 447732.275}, {88843.765, 447718.255}, {88843.117, 447720.147}}},
-			want:    map[tms20.TMID][]geom.Polygon{0: {{{{88875.2, 447624.64}, {88875.2, 447839.68}}}}},
-		},
-		{
 			name:  "rightmostLowestPoint is one of the deduped points",
 			tms:   loadEmbeddedTileMatrixSet(t, "NetherlandsRDNewQuad"),
 			tmIDs: []tms20.TMID{5},


### PR DESCRIPTION
Reverts PDOK/texel#29

de test is niet nodig. het werd nooit die polygon met 4 punten. texel maakt een lijn cq ring met 2 punten. het eerste punt wordt herhaald op het eind, zoals gewoonlijk in een polygon. en het punt werd nog een keer herhaald in een of andere import stap in een controle.