### PR TITLE
fix webmercator panic (shifting quadrants)

### DIFF
--- a/intgeom/extent.go
+++ b/intgeom/extent.go
@@ -6,20 +6,20 @@ import (
 
 // Extenter represents an interface that returns a boundbox.
 type Extenter interface {
-	Extent() (extent [4]int64)
+	Extent() (extent [4]M)
 }
 
 // MinMaxer is a wrapper for an Extent that gets min/max of the extent
 type MinMaxer interface {
-	MinX() int64
-	MinY() int64
-	MaxX() int64
-	MaxY() int64
+	MinX() M
+	MinY() M
+	MaxX() M
+	MaxY() M
 }
 
 // Extent represents the minx, miny, maxx and maxy
 // A nil extent represents the whole universe.
-type Extent [4]int64
+type Extent [4]M
 
 func (e Extent) ToGeomExtent() geom.Extent {
 	return geom.Extent{
@@ -43,8 +43,8 @@ func FromGeomExtent(e geom.Extent) Extent {
 
 // Vertices return the vertices of the Bounding Box. The vertices are ordered in the following manner.
 // (minx,miny), (maxx,miny), (maxx,maxy), (minx,maxy)
-func (e Extent) Vertices() [][2]int64 {
-	return [][2]int64{
+func (e Extent) Vertices() [][2]M {
+	return [][2]M{
 		{e.MinX(), e.MinY()},
 		{e.MaxX(), e.MinY()},
 		{e.MaxX(), e.MaxY()},
@@ -54,15 +54,15 @@ func (e Extent) Vertices() [][2]int64 {
 
 // ClockwiseFunc returns whether the set of points should be considered clockwise or counterclockwise.
 // The last point is not the same as the first point, and the function should connect these points as needed.
-type ClockwiseFunc func(...[2]int64) bool
+type ClockwiseFunc func(...[2]M) bool
 
 // Edges returns the clockwise order of the edges that make up the extent.
-func (e Extent) Edges(cwfn ClockwiseFunc) [][2][2]int64 {
+func (e Extent) Edges(cwfn ClockwiseFunc) [][2][2]M {
 	v := e.Vertices()
 	if cwfn != nil && !cwfn(v...) {
 		v[0], v[1], v[2], v[3] = v[3], v[2], v[1], v[0]
 	}
-	return [][2][2]int64{
+	return [][2][2]M{
 		{v[0], v[1]},
 		{v[1], v[2]},
 		{v[2], v[3]},
@@ -71,36 +71,36 @@ func (e Extent) Edges(cwfn ClockwiseFunc) [][2][2]int64 {
 }
 
 // MaxX is the larger of the x values.
-func (e Extent) MaxX() int64 {
+func (e Extent) MaxX() M {
 	return e[2]
 }
 
 // MinX  is the smaller of the x values.
-func (e Extent) MinX() int64 {
+func (e Extent) MinX() M {
 	return e[0]
 }
 
 // MaxY is the larger of the y values.
-func (e Extent) MaxY() int64 {
+func (e Extent) MaxY() M {
 	return e[3]
 }
 
 // MinY is the smaller of the y values.
-func (e Extent) MinY() int64 {
+func (e Extent) MinY() M {
 	return e[1]
 }
 
 // XSpan is the distance of the Extent in X
-func (e Extent) XSpan() int64 {
+func (e Extent) XSpan() M {
 	return e[2] - e[0]
 }
 
 // YSpan is the distance of the Extent in Y
-func (e Extent) YSpan() int64 {
+func (e Extent) YSpan() M {
 	return e[3] - e[1]
 }
 
 // Extent returns back the min and max of the Extent
-func (e Extent) Extent() [4]int64 {
-	return [4]int64{e.MinX(), e.MinY(), e.MaxX(), e.MaxY()}
+func (e Extent) Extent() [4]M {
+	return [4]M{e.MinX(), e.MinY(), e.MaxX(), e.MaxY()}
 }

--- a/intgeom/intgeom.go
+++ b/intgeom/intgeom.go
@@ -1,10 +1,14 @@
 // Package intgeom resembles github.com/go-spatial/geom but uses int64s internally
 // to avoid floating point errors when performing arithmetic with the coords.
+//
 // The idea is that an int64's range (math.MaxInt64) is enough for (most) (earthly) geom operations.
 // See https://www.explainxkcd.com/wiki/index.php/2170:_Coordinate_Precision.
-// Using the last 9 digits as decimals should be enough for identifying
+// Using the last 10 digits as decimals should be enough for identifying
 // the location of a grain of sand (in degrees).
-// That leaves 10 digits for the whole units of measurement in your SRS.
+// More importantly, 10 digits are necessary to minimize the rounding error
+// when the span of a matrix is divided by its size (in pixels) on deeper levels.
+//
+// That leaves 9 digits for the whole units of measurement in your SRS.
 // If that unit is degrees, it's more than enough (a circle only has 360).
 // If that unit is feet, earth's circumference (131 482 560) also still fits.
 // This is not intended to cover everything. go-spatial/geom has much more functionality.
@@ -22,13 +26,18 @@ import (
 
 const (
 	debug     = false
-	Precision = 9
+	Precision = 10
+	Half      = 5000000000
+	One       = 10000000000
 )
 
-type Ord = int64
+// M is short for measure.
+// Used to indicate that a distance or ordinate is saved as an int64 and needs division by Precision (eventually).
+// Shortened for readability in long lines (in other packages it will also be prefixed with intgeom.)
+type M = int64
 
 // ToGeomOrd turns an ordinate represented as an integer back into a floating point
-func ToGeomOrd(o Ord) float64 {
+func ToGeomOrd(o M) float64 {
 	if o == 0 {
 		return 0.0
 	}
@@ -36,7 +45,7 @@ func ToGeomOrd(o Ord) float64 {
 }
 
 // FromGeomOrd turns a floating point ordinate into a representation by an integer
-func FromGeomOrd(o float64) Ord {
+func FromGeomOrd(o float64) M {
 	return int64(o * math.Pow(10, Precision))
 }
 
@@ -51,14 +60,14 @@ func SegmentIntersect(l1, l2 Line) ([2]int64, bool) {
 	return intIntersection, intersects
 }
 
-func PrintWithDecimals(o Ord, n uint) string {
+func PrintWithDecimals(o M, n uint) string {
 	s := fmt.Sprintf("%0"+strconv.Itoa(Precision+1)+"d", o)
 	l := len(s)
 	m := s[l-Precision : l]
 	if n < Precision {
 		m = m[0:n]
 	} else {
-		m = m + strings.Repeat("0", int(n-Precision))
+		m += strings.Repeat("0", int(n-Precision))
 	}
 	c := s[0 : l-Precision]
 	return c + "." + m

--- a/intgeom/intgeom.go
+++ b/intgeom/intgeom.go
@@ -11,24 +11,33 @@
 // You are not required to use this.
 package intgeom
 
-import "github.com/go-spatial/geom/planar"
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/go-spatial/geom/planar"
+)
 
 const (
 	debug     = false
-	Precision = 1e09
+	Precision = 9
 )
 
+type Ord = int64
+
 // ToGeomOrd turns an ordinate represented as an integer back into a floating point
-func ToGeomOrd(o int64) float64 {
+func ToGeomOrd(o Ord) float64 {
 	if o == 0 {
 		return 0.0
 	}
-	return float64(o) / Precision
+	return float64(o) / math.Pow(10, Precision)
 }
 
 // FromGeomOrd turns a floating point ordinate into a representation by an integer
-func FromGeomOrd(o float64) int64 {
-	return int64(o * Precision)
+func FromGeomOrd(o float64) Ord {
+	return int64(o * math.Pow(10, Precision))
 }
 
 // SegmentIntersect will find the intersection point (x,y) between two lines if
@@ -40,4 +49,17 @@ func SegmentIntersect(l1, l2 Line) ([2]int64, bool) {
 	intersection, intersects := planar.SegmentIntersect(l1.ToGeomLine(), l2.ToGeomLine())
 	intIntersection := [2]int64{FromGeomOrd(intersection[0]), FromGeomOrd(intersection[0])}
 	return intIntersection, intersects
+}
+
+func PrintWithDecimals(o Ord, n uint) string {
+	s := fmt.Sprintf("%0"+strconv.Itoa(Precision+1)+"d", o)
+	l := len(s)
+	m := s[l-Precision : l]
+	if n < Precision {
+		m = m[0:n]
+	} else {
+		m = m + strings.Repeat("0", int(n-Precision))
+	}
+	c := s[0 : l-Precision]
+	return c + "." + m
 }

--- a/intgeom/line.go
+++ b/intgeom/line.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Line has exactly two points
-type Line [2][2]int64
+type Line [2][2]M
 
 func (l Line) ToGeomLine() geom.Line {
 	return geom.Line{
@@ -35,10 +35,10 @@ func (l Line) Point1() *Point { return (*Point)(&l[0]) }
 // Point2 returns a new copy of the second point in the line.
 func (l Line) Point2() *Point { return (*Point)(&l[1]) }
 
-func (l Line) Vertices() [][2]int64 { return l[:] }
+func (l Line) Vertices() [][2]M { return l[:] }
 
 // ContainsPoint checks to see if the given pont lines on the line segment. (Including the end points.)
-func (l Line) ContainsPoint(pt [2]int64) bool {
+func (l Line) ContainsPoint(pt [2]M) bool {
 	minx, maxx := l[0][0], l[1][0]
 	if minx > maxx {
 		minx, maxx = maxx, minx

--- a/intgeom/point.go
+++ b/intgeom/point.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Point describes a simple 2D point
-type Point [2]int64
+type Point [2]M
 
 func (p Point) ToGeomPoint() geom.Point {
 	return geom.Point{
@@ -22,18 +22,18 @@ func FromGeomPoint(p geom.Point) Point {
 }
 
 // XY returns an array of 2D coordinates
-func (p Point) XY() [2]int64 {
+func (p Point) XY() [2]M {
 	return p
 }
 
 // SetXY sets a pair of coordinates
-func (p Point) SetXY(xy [2]int64) {
+func (p Point) SetXY(xy [2]M) {
 	p[0] = xy[0]
 	p[1] = xy[1]
 }
 
 // X is the x coordinate of a point in the projection
-func (p Point) X() int64 { return p[0] }
+func (p Point) X() M { return p[0] }
 
 // Y is the y coordinate of a point in the projection
-func (p Point) Y() int64 { return p[1] }
+func (p Point) Y() M { return p[1] }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,10 @@ import (
 	"log"
 	"os"
 	"path"
+	"slices"
 	"syscall"
+
+	"github.com/pdok/texel/pointindex"
 
 	"github.com/go-spatial/geom"
 
@@ -101,6 +104,9 @@ func main() {
 		if err != nil {
 			return err
 		}
+		if err = validateTileMatrixSet(tileMatrixSet, tileMatrixIDs); err != nil {
+			return err
+		}
 
 		_, err = os.Stat(c.String(SOURCE))
 		if os.IsNotExist(err) {
@@ -156,6 +162,19 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func validateTileMatrixSet(tms tms20.TileMatrixSet, tileMatrixIDs []tms20.TMID) error {
+	deepestTMID := slices.Max(tileMatrixIDs)
+	stats, deviationInUnits, deviationInPixels, err := pointindex.DeviationStats(tms, deepestTMID)
+	if err != nil {
+		return err
+	}
+	if deviationInPixels >= 1 {
+		log.Printf("warning, (largest) deviation is larger than 1 tile pixel (%f units) on the deepest matrix (%d)\n", deviationInUnits, deepestTMID)
+		log.Println(stats)
+	}
+	return nil
 }
 
 func initGPKGTarget(targetPathFmt string, tmID int, overwrite bool, pagesize int) *gpkg.TargetGeopackage {

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func validateTileMatrixSet(tms tms20.TileMatrixSet, tileMatrixIDs []tms20.TMID) 
 		log.Printf("warning, (largest) deviation is larger than 1 tile pixel (%f units) on the deepest matrix (%d)\n", deviationInUnits, deepestTMID)
 		log.Println(stats)
 	}
-	return nil
+	return pointindex.IsQuadTree(tms)
 }
 
 func initGPKGTarget(targetPathFmt string, tmID int, overwrite bool, pagesize int) *gpkg.TargetGeopackage {

--- a/mathhelp/mathhelp.go
+++ b/mathhelp/mathhelp.go
@@ -1,6 +1,13 @@
 package mathhelp
 
-func BetweenInc(f, p, q int64) bool {
+func IBetweenInc(f, p, q int64) bool {
+	if p <= q {
+		return p <= f && f <= q
+	}
+	return q <= f && f <= p
+}
+
+func FBetweenInc(f, p, q float64) bool {
 	if p <= q {
 		return p <= f && f <= q
 	}

--- a/snap/snap.go
+++ b/snap/snap.go
@@ -35,7 +35,10 @@ type IsOuter = bool
 //nolint:revive
 func SnapPolygon(polygon geom.Polygon, tileMatrixSet tms20.TileMatrixSet, tmIDs []tms20.TMID, keepPointsAndLines bool) map[tms20.TMID][]geom.Polygon {
 	deepestID := slices.Max(tmIDs)
-	ix := pointindex.FromTileMatrixSet(tileMatrixSet, deepestID)
+	ix, err := pointindex.FromTileMatrixSet(tileMatrixSet, deepestID)
+	if err != nil {
+		panic(err) // TODO let processing.processPolygonFunc return err
+	}
 	tmIDsByLevels := tileMatrixIDsByLevels(tileMatrixSet, tmIDs)
 	levels := make([]pointindex.Level, 0, len(tmIDsByLevels))
 	for level := range tmIDsByLevels {

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -688,6 +688,16 @@ func TestSnap_snapPolygon(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:               "no points found panic on TMS other than RD",
+			tms:                loadEmbeddedTileMatrixSet(t, "WebMercatorQuad"),
+			tmIDs:              []tms20.TMID{17},
+			keepPointsAndLines: true,
+			polygon: geom.Polygon{
+				{{642743.3299, 6898063.027}, {642694.6797, 6898049.319}, {642671.3143, 6898042.735}, {642671.3143, 6898042.735}, {642668.1822, 6898053.868}, {642740.1897, 6898074.148}},
+			},
+			want: map[tms20.TMID][]geom.Polygon{}, // want no panicNoPointsFoundForVertices
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -915,18 +915,18 @@ func Test_dedupeInnersOuters(t *testing.T) {
 }
 
 // newSimpleTileMatrixSet creates a tms for snap testing purposes
-// the effective quadrant amount (one axis) on the deepest level will be 2^maxDepth * 16 (vt internal pixel res)
+// the effective quadrant amount (one axis) on the deepest level will be 2^deepestLevel * 16 (vt internal pixel res)
 // the effective quadrant size (one axis) on the deepest level will be cellSize / 16 (vt internal pixel res)
-func newSimpleTileMatrixSet(maxDepth pointindex.Level, cellSize float64) tms20.TileMatrixSet {
+func newSimpleTileMatrixSet(deepestTMID pointindex.Level, cellSize float64) tms20.TileMatrixSet {
 	zeroZero := tms20.TwoDPoint([2]float64{0.0, 0.0})
 	tms := tms20.TileMatrixSet{
 		CRS:          fakeCRS{},
 		OrderedAxes:  []string{"X", "Y"},
-		TileMatrices: make(map[tms20.TMID]tms20.TileMatrix, maxDepth+1),
+		TileMatrices: make(map[tms20.TMID]tms20.TileMatrix, deepestTMID+1),
 	}
-	for tmID := 0; tmID <= int(maxDepth); tmID++ {
+	for tmID := 0; tmID <= int(deepestTMID); tmID++ {
 		// (only values from the root tm are used, for the rest it is assumed to follow quad matrix rules)
-		tmCellSize := cellSize * float64(mathhelp.Pow2(maxDepth-uint(tmID)))
+		tmCellSize := cellSize * float64(mathhelp.Pow2(deepestTMID-uint(tmID)))
 		tms.TileMatrices[tmID] = tms20.TileMatrix{
 			ID:               "0",
 			ScaleDenominator: tmCellSize / tms20.StandardizedRenderingPixelSize,
@@ -942,7 +942,6 @@ func newSimpleTileMatrixSet(maxDepth pointindex.Level, cellSize float64) tms20.T
 	return tms
 }
 
-//nolint:unparam
 func loadEmbeddedTileMatrixSet(t *testing.T, tmsID string) tms20.TileMatrixSet {
 	tms, err := tms20.LoadEmbeddedTileMatrixSet(tmsID)
 	require.NoError(t, err)

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -1,6 +1,7 @@
 package snap
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/pdok/texel/geomhelp"
@@ -928,7 +929,7 @@ func newSimpleTileMatrixSet(deepestTMID pointindex.Level, cellSize float64) tms2
 		// (only values from the root tm are used, for the rest it is assumed to follow quad matrix rules)
 		tmCellSize := cellSize * float64(mathhelp.Pow2(deepestTMID-uint(tmID)))
 		tms.TileMatrices[tmID] = tms20.TileMatrix{
-			ID:               "0",
+			ID:               strconv.Itoa(tmID),
 			ScaleDenominator: tmCellSize / tms20.StandardizedRenderingPixelSize,
 			CellSize:         tmCellSize,
 			CornerOfOrigin:   tms20.BottomLeft,


### PR DESCRIPTION
# Description

Quadrants were not aligned exactly (as required by checking for recursive line intersection) when matrix span / cell size was not an exact number. (It is with NetherlandsRDNewQuad, but not with e.g. WebMercatorQuad and EuropeanETRS89_LAEAQuad).

The gist of it is [here](https://github.com/PDOK/texel/pull/35/files#diff-b329703782c76e6be24de85786ca157f100dd2e2d31f883a1570de59027229a5L126)

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR