### PR TITLE
feat: reversewindingorder

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ const TILEMATRICES string = `tilematrices`
 const PAGESIZE string = `pagesize`
 const KEEPPOINTSANDLINES string = `keeppointsandlines`
 const IGNOREOUTSIDEGRID string = `ignoreoutsidegrid`
+const REVERSEWINDINGORDER string = `reversewindingorder`
 
 //nolint:funlen
 func main() {
@@ -102,6 +103,14 @@ func main() {
 			Required: false,
 			EnvVars:  []string{strcase.ToScreamingSnake(IGNOREOUTSIDEGRID)},
 		},
+		&cli.BoolFlag{
+			Name:     REVERSEWINDINGORDER,
+			Aliases:  []string{"rwo"},
+			Usage:    "Reverse the winding order of rings in polygons, contrary to the OGC simple features spec",
+			Value:    false,
+			Required: false,
+			EnvVars:  []string{strcase.ToScreamingSnake(REVERSEWINDINGORDER)},
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -133,8 +142,9 @@ func main() {
 		overwrite := c.Bool(OVERWRITE)
 		pagesize := c.Int(PAGESIZE) // TODO divide by tile matrices count
 		snapConfig := snap.Config{
-			KeepPointsAndLines: c.Bool(KEEPPOINTSANDLINES),
-			IgnoreOutsideGrid:  c.Bool(IGNOREOUTSIDEGRID),
+			KeepPointsAndLines:  c.Bool(KEEPPOINTSANDLINES),
+			IgnoreOutsideGrid:   c.Bool(IGNOREOUTSIDEGRID),
+			ReverseWindingOrder: c.Bool(REVERSEWINDINGORDER),
 		}
 		for _, tmID := range tileMatrixIDs {
 			gpkgTargets[tmID] = initGPKGTarget(targetPathFmt, tmID, overwrite, pagesize)

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -715,6 +715,70 @@ func TestSnap_snapPolygon(t *testing.T) {
 			polygon: geom.Polygon{{{0.1, 0.1}, {0.2, 0.1}, {0.2, -0.1}}},
 			want:    map[tms20.TMID][]geom.Polygon{}, // empty, ignored
 		},
+		{
+			name:   "correct winding order",
+			tms:    newSimpleTileMatrixSet(2, 64),
+			config: Config{ReverseWindingOrder: false},
+			tmIDs:  []tms20.TMID{1},
+			polygon: geom.Polygon{
+				{{60.0, 124.0}, {60.0, 4.0}, {4.0, 4.0}, {4.0, 124.0}},                   // cw
+				{{12.0, 76.0}, {28.0, 76.0}, {52.0, 76.0}, {52.0, 116.0}, {12.0, 116.0}}, // ccw
+			},
+			want: map[tms20.TMID][]geom.Polygon{
+				1: {{
+					{{4.0, 124.0}, {4.0, 4.0}, {60.0, 4.0}, {60.0, 124.0}},                   // ccw
+					{{12.0, 116.0}, {52.0, 116.0}, {52.0, 76.0}, {28.0, 76.0}, {12.0, 76.0}}, // cw
+				}},
+			},
+		},
+		{
+			name:   "reverse winding order",
+			tms:    newSimpleTileMatrixSet(2, 64),
+			config: Config{ReverseWindingOrder: true},
+			tmIDs:  []tms20.TMID{1},
+			polygon: geom.Polygon{
+				{{4.0, 124.0}, {4.0, 4.0}, {60.0, 4.0}, {60.0, 124.0}},                   // ccw
+				{{12.0, 116.0}, {52.0, 116.0}, {52.0, 76.0}, {28.0, 76.0}, {12.0, 76.0}}, // cw
+			},
+			want: map[tms20.TMID][]geom.Polygon{
+				1: {{
+					{{60.0, 124.0}, {60.0, 4.0}, {4.0, 4.0}, {4.0, 124.0}},                   // cw
+					{{12.0, 76.0}, {28.0, 76.0}, {52.0, 76.0}, {52.0, 116.0}, {12.0, 116.0}}, // ccw
+				}},
+			},
+		},
+		{
+			name:   "do not reverse winding order",
+			tms:    newSimpleTileMatrixSet(2, 64),
+			config: Config{ReverseWindingOrder: false},
+			tmIDs:  []tms20.TMID{1},
+			polygon: geom.Polygon{
+				{{4.0, 124.0}, {4.0, 4.0}, {60.0, 4.0}, {60.0, 124.0}},                   // ccw
+				{{12.0, 116.0}, {52.0, 116.0}, {52.0, 76.0}, {28.0, 76.0}, {12.0, 76.0}}, // cw
+			},
+			want: map[tms20.TMID][]geom.Polygon{
+				1: {{
+					{{4.0, 124.0}, {4.0, 4.0}, {60.0, 4.0}, {60.0, 124.0}},                   // ccw
+					{{12.0, 116.0}, {52.0, 116.0}, {52.0, 76.0}, {28.0, 76.0}, {12.0, 76.0}}, // cw
+				}},
+			},
+		},
+		{
+			name:   "keep reversed winding order",
+			tms:    newSimpleTileMatrixSet(2, 64),
+			config: Config{ReverseWindingOrder: true},
+			tmIDs:  []tms20.TMID{1},
+			polygon: geom.Polygon{
+				{{60.0, 124.0}, {60.0, 4.0}, {4.0, 4.0}, {4.0, 124.0}},                   // cw
+				{{12.0, 76.0}, {28.0, 76.0}, {52.0, 76.0}, {52.0, 116.0}, {12.0, 116.0}}, // ccw
+			},
+			want: map[tms20.TMID][]geom.Polygon{
+				1: {{
+					{{60.0, 124.0}, {60.0, 4.0}, {4.0, 4.0}, {4.0, 124.0}},                   // cw
+					{{12.0, 76.0}, {28.0, 76.0}, {52.0, 76.0}, {52.0, 116.0}, {12.0, 116.0}}, // ccw
+				}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

add an option/flag to reverse polygons' rings' winding order. normally ogc simple features winding order is ensured. with this flag it's the reverse (for mapbox vector tiles)

PDOK-16853

## Type of change

- New feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR